### PR TITLE
Updated file location for splunk-ca.crt

### DIFF
--- a/charts/openshift-logforwarding-splunk/templates/log-forwarding-splunk-configmap.yaml
+++ b/charts/openshift-logforwarding-splunk/templates/log-forwarding-splunk-configmap.yaml
@@ -53,7 +53,7 @@ data:
       hec_token "#{ENV['SPLUNK_TOKEN'] }"
       host "#{ENV['NODE_NAME']}"
       {{- if and (not .Values.forwarding.splunk.insecure) .Values.forwarding.splunk.caFile }}
-      ca_file /secrets/splunk/splunk-ca.crt
+      ca_file /secret/splunk/splunk-ca.crt
       {{- end }}
       {{- with .Values.forwarding.fluentd.buffer }}
       <buffer>


### PR DESCRIPTION
The `ca_file` is mounted in /secret in the pods, not /secrets